### PR TITLE
Add baseUrl property

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var WEBVIEW_REF = 'androidWebView';
 var WebViewAndroid = React.createClass({
   propTypes: {
     url: PropTypes.string,
+    baseUrl: PropTypes.string,
     html: PropTypes.string,
     htmlCharset: PropTypes.string,
     injectedJavaScript: PropTypes.string,

--- a/src/main/java/com/burnweb/rnwebview/RNWebView.java
+++ b/src/main/java/com/burnweb/rnwebview/RNWebView.java
@@ -54,6 +54,7 @@ import com.facebook.react.uimanager.events.EventDispatcher;
     private final EventDispatcher mEventDispatcher;
     private final EventWebClient mWebViewClient;
     private String charset = "UTF-8";
+    private String baseUrl = "file:///";
 
     public RNWebView(ReactContext reactContext) {
         super(reactContext);
@@ -93,6 +94,14 @@ import com.facebook.react.uimanager.events.EventDispatcher;
 
     public String getInjectedJavaScript() {
         return mWebViewClient.getInjectedJavaScript();
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getBaseUrl() {
+        return this.baseUrl;
     }
 
     public GeoWebChromeClient getGeoClient() {

--- a/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
+++ b/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
@@ -77,6 +77,11 @@ public class RNWebViewManager extends ViewGroupManager<RNWebView> {
         view.loadUrl(url);
     }
 
+    @ReactProp(name = "baseUrl")
+    public void setBaseUrl(RNWebView view, @Nullable String baseUrl) {
+        view.setBaseUrl(baseUrl);
+    }
+
     @ReactProp(name = "htmlCharset")
     public void setHtmlCharset(RNWebView view, @Nullable String htmlCharset) {
         if(htmlCharset != null) view.setCharset(htmlCharset);
@@ -84,7 +89,7 @@ public class RNWebViewManager extends ViewGroupManager<RNWebView> {
 
     @ReactProp(name = "html")
     public void setHtml(RNWebView view, @Nullable String html) {
-        view.loadData(html, "text/html", view.getCharset());
+        view.loadDataWithBaseURL(view.getBaseUrl(), html, "text/html", view.getCharset(), null);
     }
 
     @ReactProp(name = "injectedJavaScript")


### PR DESCRIPTION
I added a baseUrl property in order to improve the html property of the WebView.

Now you can do stuff like this:
 ```
      <WebView
        ref={'WebView'}
        html={'<script>sessionStorage.Foo = 'bar';</script>'}
        baseUrl={'https://example.com/'}
        style={styles.containerWebView} />
```