### PR TITLE
Update ReactProp imports for React Native 0.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.13.+'
+    compile 'com.facebook.react:react-native:0.19.+'
 }
-

--- a/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
+++ b/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
@@ -11,7 +11,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.common.annotations.VisibleForTesting;
 
 import java.util.Map;


### PR DESCRIPTION
Needed because of this:
https://github.com/facebook/react-native/commit/c1b7a369af7ca457819d682b15f47fae7e2732fc

This won't be compatible with older versions of RN though.