### PR TITLE
Fixed broken fullscreen modals due to zero body height.

### DIFF
--- a/android/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
+++ b/android/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
+import android.view.ViewGroup.LayoutParams;
 import android.webkit.WebSettings;
 import android.webkit.CookieManager;
 
@@ -41,6 +42,11 @@ public class RNWebViewManager extends SimpleViewManager<RNWebView> {
     public RNWebView createViewInstance(ThemedReactContext context) {
         RNWebView rnwv = new RNWebView(this, context);
 
+        // Fixes broken full-screen modals/galleries due to body
+        // height being 0.
+        rnwv.setLayoutParams(
+                new LayoutParams(LayoutParams.MATCH_PARENT,
+                    LayoutParams.MATCH_PARENT));
         CookieManager.getInstance().setAcceptCookie(true); // add default cookie support
         CookieManager.getInstance().setAcceptFileSchemeCookies(true); // add default cookie support
 

--- a/index.android.js
+++ b/index.android.js
@@ -9,6 +9,8 @@ try {
   var React = require('react-native');
 }
 
+var RN = require("react-native");
+
 var { requireNativeComponent, NativeModules } = require('react-native');
 var RCTUIManager = NativeModules.UIManager;
 
@@ -61,7 +63,7 @@ var WebViewAndroid = React.createClass({
     return <RNWebViewAndroid ref={WEBVIEW_REF} {...this.props} onNavigationStateChange={this._onNavigationStateChange} />;
   },
   _getWebViewHandle: function() {
-    return React.findNodeHandle(this.refs[WEBVIEW_REF]);
+    return RN.findNodeHandle(this.refs[WEBVIEW_REF]);
   },
 });
 


### PR DESCRIPTION
JavaScript plugins such as Fotorama are broken when attempting use its fullscreen feature.
This commit fixes it.