### PR TITLE
React 16 friendly

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -9,6 +9,8 @@ try {
   var React = require('react-native');
 }
 
+var createClass = require('create-react-class');
+var PropType = require('prop-types');
 var RN = require("react-native");
 
 var { requireNativeComponent, NativeModules } = require('react-native');
@@ -16,22 +18,22 @@ var RCTUIManager = NativeModules.UIManager;
 
 var WEBVIEW_REF = 'androidWebView';
 
-var WebViewAndroid = React.createClass({
+var WebViewAndroid = createClass({
   propTypes: {
-    url: React.PropTypes.string,
-    source: React.PropTypes.object,
-    baseUrl: React.PropTypes.string,
-    html: React.PropTypes.string,
-    htmlCharset: React.PropTypes.string,
-    userAgent: React.PropTypes.string,
-    injectedJavaScript: React.PropTypes.string,
-    disablePlugins: React.PropTypes.bool,
-    disableCookies: React.PropTypes.bool,
-    javaScriptEnabled: React.PropTypes.bool,
-    geolocationEnabled: React.PropTypes.bool,
-    allowUrlRedirect: React.PropTypes.bool,
-    builtInZoomControls: React.PropTypes.bool,
-    onNavigationStateChange: React.PropTypes.func
+    url: PropTypes.string,
+    source: PropTypes.object,
+    baseUrl: PropTypes.string,
+    html: PropTypes.string,
+    htmlCharset: PropTypes.string,
+    userAgent: PropTypes.string,
+    injectedJavaScript: PropTypes.string,
+    disablePlugins: PropTypes.bool,
+    disableCookies: PropTypes.bool,
+    javaScriptEnabled: PropTypes.bool,
+    geolocationEnabled: PropTypes.bool,
+    allowUrlRedirect: PropTypes.bool,
+    builtInZoomControls: PropTypes.bool,
+    onNavigationStateChange: PropTypes.func
   },
   _onNavigationStateChange: function(event) {
     if (this.props.onNavigationStateChange) {

--- a/index.android.js
+++ b/index.android.js
@@ -10,7 +10,7 @@ try {
 }
 
 var createClass = require('create-react-class');
-var PropType = require('prop-types');
+var PropTypes = require('prop-types');
 var RN = require("react-native");
 
 var { requireNativeComponent, NativeModules } = require('react-native');

--- a/index.ios.js
+++ b/index.ios.js
@@ -8,10 +8,11 @@ try {
 } catch(ex) {
   var React = require('react-native');
 }
+var createClass = require('create-react-class');
 
 var { StyleSheet } = require('react-native');
 
-var UnimplementedView = React.createClass({
+var UnimplementedView = createClass({
   setNativeProps: function() {
     // Do nothing.
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webview-android",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Simple React Native Android module to use Android's WebView inside your app",
   "main": "index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
   "bugs": "https://github.com/lucasferreira/react-native-webview-android/issues",
   "peerDependencies": {
     "react-native": ">=0.26"
+  },
+  "dependencies": {
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
React 16 has deprecated  React.PropTypes and React.createClass. Instead packages that have not updated to ES6 classes can add drop-in replacements for these 2. I've added them to this package so anyone (like me) using latest React and React Native can use it