### PR TITLE
Added support for onShouldStartLoadWithRequest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ var WebViewAndroidExample = React.createClass({
       // executes JavaScript immediately in web view
       this.refs.webViewAndroidSample.injectJavaScript(script);
     },
+    onShouldStartLoadWithRequest: function(event) {
+      // currently only url & navigationState are returned in the event.
+      console.log(event.url);
+      console.log(event.navigationState);
+
+      if (event.url === 'https://www.mywebsiteexample.com/') {
+        return true;
+      } else {
+        return false;
+      }
+    },
     onNavigationStateChange: function(event) {
       console.log(event);
 
@@ -142,6 +153,7 @@ var WebViewAndroidExample = React.createClass({
           geolocationEnabled={false}
           builtInZoomControls={false}
           injectedJavaScript={this.javascriptToInject()}
+          onShouldStartLoadWithRequest={this.onShouldStartLoadWithRequest}
           onNavigationStateChange={this.onNavigationStateChange}
           onMessage={this.onMessage}
           url={SITE_URL} // or use the source(object) attribute...
@@ -158,6 +170,10 @@ var styles = StyleSheet.create({
   }
 });
 ```
+
+## Note about onShouldStartLoadWithRequest
+
+This module has a working implementation of onShouldStartLoadWithRequest. However, the event it returns currently only includes `url` and `navigationState`.
 
 ## Note about HTML file input (files upload)
 

--- a/android/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
+++ b/android/src/main/java/com/burnweb/rnwebview/RNWebViewManager.java
@@ -30,6 +30,7 @@ public class RNWebViewManager extends SimpleViewManager<RNWebView> {
     public static final int STOP_LOADING = 4;
     public static final int POST_MESSAGE = 5;
     public static final int INJECT_JAVASCRIPT = 6;
+    public static final int SHOULD_OVERRIDE_WITH_RESULT = 7;
 
     private static final String HTML_MIME_TYPE = "text/html";
 
@@ -183,7 +184,8 @@ public class RNWebViewManager extends SimpleViewManager<RNWebView> {
             "reload", RELOAD,
             "stopLoading", STOP_LOADING,
             "postMessage", POST_MESSAGE,
-            "injectJavaScript", INJECT_JAVASCRIPT
+            "injectJavaScript", INJECT_JAVASCRIPT,
+            "shouldOverrideWithResult", SHOULD_OVERRIDE_WITH_RESULT
         );
     }
 
@@ -224,6 +226,9 @@ public class RNWebViewManager extends SimpleViewManager<RNWebView> {
             case INJECT_JAVASCRIPT:
                 view.loadUrl("javascript:" + args.getString(0));
                 break;
+            case SHOULD_OVERRIDE_WITH_RESULT:
+                view.shouldOverrideWithResult(view, args);
+                break;
         }
     }
 
@@ -232,6 +237,7 @@ public class RNWebViewManager extends SimpleViewManager<RNWebView> {
         return MapBuilder.<String, Object>builder()
             .put(NavigationStateChangeEvent.EVENT_NAME, MapBuilder.of("registrationName", "onNavigationStateChange"))
             .put(MessageEvent.EVENT_NAME, MapBuilder.of("registrationName", "onMessageEvent"))
+            .put(ShouldOverrideUrlLoadingEvent.EVENT_NAME, MapBuilder.of("registrationName", "onShouldOverrideUrlLoading"))
             .build();
     }
 

--- a/android/src/main/java/com/burnweb/rnwebview/ShouldOverrideUrlLoadingEvent.java
+++ b/android/src/main/java/com/burnweb/rnwebview/ShouldOverrideUrlLoadingEvent.java
@@ -1,0 +1,39 @@
+package com.burnweb.rnwebview;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class ShouldOverrideUrlLoadingEvent extends Event<ShouldOverrideUrlLoadingEvent> {
+
+  public static final String EVENT_NAME = "shouldOverrideUrlLoading";
+
+  private final String mUrl;
+  private final int mNavigationType;
+
+  public ShouldOverrideUrlLoadingEvent(int viewId, long timestampMs, String url, int navigationType) {
+    super(viewId);
+
+    mUrl = url;
+    mNavigationType = navigationType;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putString("url", mUrl);
+    eventData.putInt("navigationType", mNavigationType);
+
+    return eventData;
+  }
+}

--- a/index.android.js
+++ b/index.android.js
@@ -29,7 +29,8 @@ var WebViewAndroid = createClass({
     allowUrlRedirect: PropTypes.bool,
     builtInZoomControls: PropTypes.bool,
     onNavigationStateChange: PropTypes.func,
-    onMessage: PropTypes.func
+    onMessage: PropTypes.func,
+    onShouldStartLoadWithRequest: PropTypes.func,
   },
   _onNavigationStateChange: function(event) {
     if (this.props.onNavigationStateChange) {
@@ -40,6 +41,19 @@ var WebViewAndroid = createClass({
     if (this.props.onMessage) {
       this.props.onMessage(event.nativeEvent);
     }
+  },
+  _onShouldOverrideUrlLoading: function(event) {
+    let shouldOverride = false;
+
+    if (this.props.onShouldStartLoadWithRequest) {
+      shouldOverride = !this.props.onShouldStartLoadWithRequest(event.nativeEvent);
+    }
+
+    RCTUIManager.dispatchViewManagerCommand(
+      this._getWebViewHandle(),
+      RCTUIManager.RNWebViewAndroid.Commands.shouldOverrideWithResult,
+      [shouldOverride],
+    );
   },
   goBack: function() {
     RCTUIManager.dispatchViewManagerCommand(
@@ -85,11 +99,12 @@ var WebViewAndroid = createClass({
   },
   render: function() {
     return (
-      <RNWebViewAndroid 
-        ref={WEBVIEW_REF} 
-        {...this.props} 
-        onNavigationStateChange={this._onNavigationStateChange} 
-        onMessageEvent={this._onMessage} 
+      <RNWebViewAndroid
+        ref={WEBVIEW_REF}
+        {...this.props}
+        onNavigationStateChange={this._onNavigationStateChange}
+        onMessageEvent={this._onMessage}
+        onShouldOverrideUrlLoading={this._onShouldOverrideUrlLoading}
       />
     );
   },


### PR DESCRIPTION
This adds a solution to react-native-webview-android for onShouldStartLoadWithRequest support. 

The approach is fairly straightforward. 

For any URL load, shouldOverrideUrlLoading will initially return true - not allowing it to load. It will also dispatch the ShouldOverrideUrlLoadingEvent, triggering _onShouldOverrideUrlLoading in index.android.js. It then gets the result of onShouldStartLoadWithRequest at the react-native level if it's set on RNWebViewAndroid. A view manager command is sent back to the native side, which will take the onShouldStartLoadWithRequest result as shouldOverride included in the command and either allow the original url to load, or not load.

To note, onShouldStartLoadWithRequest only receives an object containing `url` and `navigationState` in this initial implementation.